### PR TITLE
フロッピーディスク暗号化を動的に切り替えられるよう対応

### DIFF
--- a/godotemu/Main.gd
+++ b/godotemu/Main.gd
@@ -4,6 +4,7 @@ onready var emulator = $Emulator
 onready var drive1_access = $Control/Drive1Access
 onready var drive2_access = $Control/Drive2Access
 
+export var is_disk_encrypt: bool = true
 export var drivea_path: String
 export var driveb_path: String
 export var harddisk0_path: String
@@ -76,6 +77,7 @@ func _ready() -> void:
 	$AudioPlayer.play()
 
 	emulator.setup()
+	emulator.set_disk_encrypt(is_disk_encrypt)
 
 	sound_samples = emulator.get_sound_samples()
 	sound_play_offset = 0

--- a/src/emulator/vm/disk.cpp
+++ b/src/emulator/vm/disk.cpp
@@ -16,10 +16,8 @@
 #define local_path(x) (x)
 #endif
 
-#ifdef USE_DISK_ENCRYPT
 void encrypt_disk(_TCHAR *path);
 void decrypt_disk(const _TCHAR *path);
-#endif
 
 // crc table
 static const uint16_t crc_table[256] = {
@@ -46,6 +44,8 @@ static const int secsize[8] = {
 };
 
 static uint8_t tmp_buffer[DISK_BUFFER_SIZE];
+
+bool DISK::is_encrypt = true;
 
 // physical format table for solid image
 typedef struct {
@@ -114,9 +114,10 @@ static const fd_format_t fd_formats[] = {
 
 void DISK::open(const _TCHAR* file_path, int bank)
 {
-#ifdef USE_DISK_ENCRYPT
-	decrypt_disk(file_path);
-#endif
+	if(is_encrypt)
+	{
+		decrypt_disk(file_path);
+	}
 
 	// check current disk image
 	if(inserted) {
@@ -709,8 +710,11 @@ void DISK::open(const _TCHAR* file_path, int bank)
 #endif
 	}
 
-	// オリジナルファイルを消す
-	FILEIO::RemoveFile(file_path);
+	if(is_encrypt)
+	{
+		// オリジナルファイルを消す
+		FILEIO::RemoveFile(file_path);
+	}
 }
 
 void DISK::close()
@@ -752,9 +756,10 @@ void DISK::close()
 					}
 					fio->Fclose();
 
-#ifdef USE_DISK_ENCRYPT
-					encrypt_disk(dest_path);
-#endif
+					if(is_encrypt)
+					{
+						encrypt_disk(dest_path);
+					}
 				}
 			}
 			
@@ -854,9 +859,10 @@ void DISK::close()
 			}
 			delete fio;
 
-#ifdef USE_DISK_ENCRYPT
-			encrypt_disk(dest_path);
-#endif
+			if(is_encrypt)
+			{
+				encrypt_disk(dest_path);
+			}
 		}
 		ejected = true;
 	}

--- a/src/emulator/vm/disk.h
+++ b/src/emulator/vm/disk.h
@@ -157,6 +157,8 @@ public:
 	int get_bytes_per_usec(double usec);
 	bool check_media_type();
 	
+	static bool is_encrypt;
+
 	bool inserted;
 	bool ejected;
 	bool write_protected;

--- a/src/gdemu.cpp
+++ b/src/gdemu.cpp
@@ -36,6 +36,8 @@ void GDEmu::_register_methods() {
     register_method("key_down", &GDEmu::key_down);
     register_method("key_up", &GDEmu::key_up);
 
+    register_method("set_disk_encrypt", &GDEmu::set_disk_encrypt);
+
     // プロパティを外に追い出す場合はこんな感じ……(とりあえず無しにしておく)
     // register_property<GDEmu, String>("drivea_path", &GDEmu::set_drivea_path, &GDEmu::get_drivea_path, "");
     // register_property<GDEmu, String>("driveb_path", &GDEmu::set_driveb_path, &GDEmu::get_driveb_path, "");

--- a/src/gdemu.h
+++ b/src/gdemu.h
@@ -15,6 +15,7 @@
 #include "emulator/common.h"
 #include "emulator/config.h"
 #include "emulator/vm/vm.h"
+#include "emulator/vm/disk.h"
 
 class EMU;
 
@@ -71,6 +72,8 @@ public:
     int is_floppy_disk_accessed();
 
     void set_app_path(String path);
+
+    void set_disk_encrypt(bool flag) { DISK::is_encrypt = flag; }
 };
 
 }

--- a/src/godotcommon.h
+++ b/src/godotcommon.h
@@ -2,8 +2,6 @@
 #ifndef GDCOMMON_H
 #define GDCOMMON_H
 
-#define USE_DISK_ENCRYPT
-
 #define ENCRYPT_FILE_EXT ".bin"
 
 void encrypt_disk(_TCHAR *path);


### PR DESCRIPTION
* 基本的には起動時に暗号化するかしないかを決定します(set_disk_encrypt()で変更)。
* 暗号化しなくても良い環境の場合は暗号化ナシの方が良いでしょう(ユーザーデータフォルダのディスクイメージをそのまま他のエミュレータで使えるため)